### PR TITLE
誤って削除してしまった内容を復元

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /tmp/**.sqlite3
+/tmp/pids/*
 *.cache
 /config/settings.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'jbuilder', '~> 2.5'
 gem 'bcrypt', '~> 3.1.7'
 
 gem 'kaminari'
+gem 'rakuten_web_service'
+gem 'config'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,19 +52,56 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
+    config (3.1.0)
+      deep_merge (~> 1.2, >= 1.2.1)
+      dry-validation (~> 1.0, >= 1.0.0)
     crass (1.0.6)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
     debase-ruby_core_source (0.10.12)
+    deep_merge (1.2.1)
+    dry-configurable (0.13.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.6)
+    dry-container (0.9.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+    dry-core (0.7.1)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.2.1)
+    dry-initializer (3.0.4)
+    dry-logic (1.2.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-schema (1.8.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.5)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.7.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.8, >= 1.8.0)
     erubi (1.10.0)
     execjs (2.8.1)
     ffi (1.15.4)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json (2.6.1)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -86,11 +123,11 @@ GEM
     mini_mime (1.1.2)
     minitest (5.14.4)
     nio4r (2.5.8)
-    nokogiri (1.11.0-x86_64-linux)
+    nokogiri (1.11.0-arm64-darwin)
       racc (~> 1.4)
     pg (1.2.3)
     puma (3.12.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -118,6 +155,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (13.0.6)
+    rakuten_web_service (1.13.1)
+      json (~> 2.3)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -136,7 +175,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (4.0.0)
+    selenium-webdriver (4.0.3)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
@@ -167,13 +206,14 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   byebug
   coffee-rails (~> 4.2)
+  config
   debase
   jbuilder (~> 2.5)
   kaminari
@@ -181,6 +221,7 @@ DEPENDENCIES
   pg
   puma (~> 3.7)
   rails (~> 5.1.7)
+  rakuten_web_service
   ruby-debug-ide
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -13,3 +13,12 @@
     padding-top: 100px;
     margin-left: 100px;
 }
+
+#search-box {
+    padding-top: 100px;
+    text-align: center;
+}
+
+span {
+    color: white;
+}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,6 +6,14 @@ class BooksController < ApplicationController
     @books = Book.all.page(params[:page]).per(5)
   end
   
+  def search
+    if params[:keyword].nil?
+      @books = nil
+    else
+      @books = RakutenWebService::Books::Book.search(title: params[:keyword])
+    end
+  end
+
   def update
     @filteredItems.each do |filteredItem|
       filteredItem.fetch_values(:name, :price, :image_url, :image)

--- a/app/views/books/_book_list.html.erb
+++ b/app/views/books/_book_list.html.erb
@@ -1,0 +1,26 @@
+<div class="books_info">
+  <h3>検索結果</h3>
+  <div style="padding: 30px;">
+    <table border="1">
+      <thead>
+        <tr>
+          <th>書籍名</th>
+          <th>価格</th>
+          <th>出版社</th>
+          <th>画像</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @books.each do |book| %>
+            <tr>
+              <td><%= book["title"] %></td>
+              <td><%= book["item_price"] %>円</td>
+              <td><%= book["publisher_name"] %></td>
+              <td><%= link_to (image_tag(book["large_image_url"])), book["item_url"], class: 'hoge' %></td>
+            </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  
+</div>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -1,0 +1,11 @@
+<div class='content'>
+  <div id="search-box">
+    <p><span>書籍検索</span></p>
+    <%= form_tag('/books/search', {method: :get}) do %>
+        <%= text_field_tag :book, "",  id: "book_search", name: "keyword", placeholder: "キーワードを打ち込んでください", style: "width: 300px;", height: "40px;" %><button title="検索" type="submit">検索</button>
+    <% end %>
+  </div>
+  <% if @books %>
+    <%= render "books/book_list" %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,10 @@
             <%= link_to("書籍一覧", "/books/index") %>
           </li>
           <li>
-            <%= link_to("書籍検索", "/books/create") %>
+            <%= link_to("書籍更新", "/books/create") %>
+          </li>
+          <li>
+            <%= link_to("書籍検索", "/books/search") %>
           </li>
           <li>
             <!-- ログアウト用のリンクを追加してください -->
@@ -55,6 +58,12 @@
           </li>
           <li>
             <%= link_to("ログイン", "/login") %>
+          </li>
+          <li>
+            <%= link_to("書籍一覧", "/books/index") %>
+          </li>
+          <li>
+            <%= link_to("書籍更新", "/books/create") %>
           </li>
         <% end %>
       </ul>

--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,0 +1,17 @@
+RakutenWebService.configure do |c|
+    # (必須) アプリケーションID
+    c.application_id = Settings.rakuten[:application_id]
+
+    # (任意) 楽天アフィリエイトID
+    c.affiliate_id = Settings.rakuten[:affiliate_id] # default: nil
+
+    # (任意) リクエストのリトライ回数
+    # 一定期間の間のリクエスト数が制限を超えた時、APIはリクエスト過多のエラーを返す。
+    # その後、クライアントは少し間を空けた後に同じリクエストを再度送る。
+    c.max_retries = 3 # default: 5
+
+    # (任意) デバッグモード
+    # trueの時、クライアントはすべてのHTTPリクエストとレスポンスを
+    # 標準エラー出力に流す。
+    c.debug = true # default: false
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   get "books/create" => "books#create"
   get "books/show" => "books#show"
   post "books/update" => "books#update"
+  get "books/get_api" => "books#get_api"
+  get "books/search" => "books#search"
   
   resources :home
   root 'home#top'

--- a/log/development.log
+++ b/log/development.log
@@ -3306,3 +3306,83 @@ Processing by BooksController#create as HTML
 Completed 200 OK in 26ms (Views: 22.7ms | ActiveRecord: 0.3ms)
 
 
+Started GET "/books/search" for ::1 at 2021-11-10 08:43:22 +0900
+  [1m[35m (3.0ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by BooksController#search as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/search.html.erb within layouts/application
+  Rendered books/search.html.erb within layouts/application (0.7ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 102ms (Views: 90.9ms | ActiveRecord: 3.8ms)
+
+
+Started GET "/books/search?utf8=%E2%9C%93&keyword=%E3%83%95%E3%83%A9%E3%83%B3%E3%82%B9%E8%AA%9E" for ::1 at 2021-11-10 08:43:25 +0900
+Processing by BooksController#search as HTML
+  Parameters: {"utf8"=>"✓", "keyword"=>"フランス語"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/search.html.erb within layouts/application
+  Rendered books/_book_list.html.erb (280.8ms)
+  Rendered books/search.html.erb within layouts/application (283.2ms)
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 341ms (Views: 320.6ms | ActiveRecord: 6.8ms)
+
+
+Started GET "/books/search" for ::1 at 2021-11-10 08:43:34 +0900
+Processing by BooksController#search as HTML
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/search.html.erb within layouts/application
+  Rendered books/search.html.erb within layouts/application (1.1ms)
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 42ms (Views: 36.7ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/books/create" for ::1 at 2021-11-10 08:43:36 +0900
+Processing by BooksController#create as HTML
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/create.html.erb within layouts/application
+  Rendered books/create.html.erb within layouts/application (1.3ms)
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 44ms (Views: 39.1ms | ActiveRecord: 1.1ms)
+
+
+Started POST "/books/update" for ::1 at 2021-11-10 08:43:38 +0900
+Processing by BooksController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"gPvAmgw4QkRft0nuMjOWw+u2HoKc89zLkd2fvndsWXaZ/hVK3CHdPgPQn2BY/IV/uiyl/Kvw/DkzG1W1piRkxg=="}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  [1m[36mBook Load (0.5ms)[0m  [1m[34mSELECT  "books".* FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "Ruby　on　Rails超入門 （たった1日で基本が身に付く！） [ 竹馬力 ]"], ["LIMIT", 1]]
+  [1m[36mBook Load (0.4ms)[0m  [1m[34mSELECT  "books".* FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "実践Ruby on Rails 4 機能拡張編【電子書籍】[ 黒田 努 ]"], ["LIMIT", 1]]
+  [1m[36mBook Load (0.1ms)[0m  [1m[34mSELECT  "books".* FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "Ruby　on　Rails　5アプリケーションプログラミング [ 山田祥寛 ]"], ["LIMIT", 1]]
+  [1m[36mBook Load (0.1ms)[0m  [1m[34mSELECT  "books".* FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "はじめてのJRuby　on　Rails 「Java」＋「Ruby」でWebアプリケーション （I／O　books） [ 清水美樹 ]"], ["LIMIT", 1]]
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mBook Exists (0.3ms)[0m  [1m[34mSELECT  1 AS one FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "はじめてのJRuby　on　Rails 「Java」＋「Ruby」でWebアプリケーション （I／O　books） [ 清水美樹 ]"], ["LIMIT", 1]]
+  [1m[35mSQL (2.8ms)[0m  [1m[32mINSERT INTO "books" ("created_at", "updated_at", "name", "price", "image_url", "image") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["created_at", "2021-11-09 23:43:38.713355"], ["updated_at", "2021-11-09 23:43:38.713355"], ["name", "はじめてのJRuby　on　Rails 「Java」＋「Ruby」でWebアプリケーション （I／O　books） [ 清水美樹 ]"], ["price", 2530], ["image_url", "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7138/9784777517138.jpg"], ["image", "t"]]
+  [1m[35m (0.8ms)[0m  [1m[35mCOMMIT[0m
+  [1m[36mBook Load (0.8ms)[0m  [1m[34mSELECT  "books".* FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "現場で使える Ruby on Rails 5速習実践ガイド【電子書籍】[ 大場 寧子 ]"], ["LIMIT", 1]]
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mBook Exists (0.4ms)[0m  [1m[34mSELECT  1 AS one FROM "books" WHERE "books"."name" = $1 LIMIT $2[0m  [["name", "現場で使える Ruby on Rails 5速習実践ガイド【電子書籍】[ 大場 寧子 ]"], ["LIMIT", 1]]
+  [1m[35mSQL (0.5ms)[0m  [1m[32mINSERT INTO "books" ("created_at", "updated_at", "name", "price", "image_url", "image") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["created_at", "2021-11-09 23:43:39.217202"], ["updated_at", "2021-11-09 23:43:39.217202"], ["name", "現場で使える Ruby on Rails 5速習実践ガイド【電子書籍】[ 大場 寧子 ]"], ["price", 3828], ["image_url", "https://thumbnail.image.rakuten.co.jp/@0_mall/rakutenkobo-ebooks/cabinet/3873/2000006853873.jpg"], ["image", "t"]]
+  [1m[35m (2.2ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/books/index
+Completed 302 Found in 1156ms (ActiveRecord: 17.5ms)
+
+
+Started GET "/books/index" for ::1 at 2021-11-10 08:43:39 +0900
+Processing by BooksController#index as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/index.html.erb within layouts/application
+  [1m[36mBook Load (1.1ms)[0m  [1m[34mSELECT  "books".* FROM "books" LIMIT $1 OFFSET $2[0m  [["LIMIT", 5], ["OFFSET", 0]]
+  [1m[35m (0.4ms)[0m  [1m[34mSELECT COUNT(*) FROM "books"[0m
+  Rendered books/index.html.erb within layouts/application (24.4ms)
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 60ms (Views: 53.0ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/books/search" for ::1 at 2021-11-10 08:43:44 +0900
+Processing by BooksController#search as HTML
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  Rendering books/search.html.erb within layouts/application
+  Rendered books/search.html.erb within layouts/application (0.9ms)
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 25ms (Views: 20.8ms | ActiveRecord: 0.7ms)
+
+


### PR DESCRIPTION
# 実装した内容
 * Githubでブランチをマージする際に、誤って削除してしまった内容の復元。
 
# この実装作業の原因と、その経緯
 * 11/3、implement_APIブランチをmasterにマージしようとした。
 * その際にミスをしたと勘違いしrevertを行なった。
 * revertの操作を誤り、masterが10/10時点の状態まで戻ってしまった。
 * Githubではrevertした内容が無視されれるため、revertした内容を再度復元することが不可能だった。

# 行なったこと
 * revert-5-origin/feature/implement_APIブランチと、masterの差分を見つつ、ファイルを修正

# 確認手順
 - [x] ログアウトしているとき、書籍検索画面へのリンクは表示されない。
 - [x] books/searchのページに遷移すると、中央部に検索フォームが表示される。
 - [x] 検索フォームにキーワードを入力すると、そのキーワードに応じた書籍が表示される。
 - [x] 書籍情報は30件で、①書籍情報、②著者、③出版社、④書影がそれぞれ表示される。

 - [ ] masterブランチにおいて上記の内容が反映されている。

# 課題
 * GitやGithubについての理解が不十分なまま作業を進めてしまった。再発防止に向けて、[githubを詳細に解説した記事①](https://atmarkit.itmedia.co.jp/ait/articles/1702/27/news022_2.html#04)、[githubを詳細に解説した記事②](https://futureys.tokyo/lets-create-pull-request-on-github/)を読み、理解を深めておく。